### PR TITLE
Add acsl custom Mavlink HEALTH message

### DIFF
--- a/cmake/sdk_common.cmake
+++ b/cmake/sdk_common.cmake
@@ -101,7 +101,8 @@ function(Build_mavlink SDK_SRC_DIR MAVLINK_INCLUDES_VAR MAVLINK_SOURCES_VAR MAVL
     set(MAV_XML ${MAV_DEF_DIR}/common.xml
                 ${MAV_DEF_DIR}/ardupilotmega.xml
                 ${MAV_DEF_DIR}/sphengineering.xml
-                ${MAV_DEF_DIR}/sensyn.xml)
+                ${MAV_DEF_DIR}/sensyn.xml
+                ${MAV_DEF_DIR}/acsl.xml)
     set(MAV_XSD ${SDK_SRC_DIR}/resources/mavlink/mavschema.xsd)
 
     set(MAVLINK_INCLUDES ${CMAKE_BINARY_DIR}/mavlink/include)

--- a/include/ugcs/vsm/mavlink_decoder.h
+++ b/include/ugcs/vsm/mavlink_decoder.h
@@ -256,7 +256,8 @@ private:
         if (    !sum.Get_extra_byte_length_pair(msg_id, crc_byte_len_pair, mavlink::Extension::Get())
             &&  !sum.Get_extra_byte_length_pair(msg_id, crc_byte_len_pair, mavlink::apm::Extension::Get())
             &&  !sum.Get_extra_byte_length_pair(msg_id, crc_byte_len_pair, mavlink::sph::Extension::Get())
-            &&  !sum.Get_extra_byte_length_pair(msg_id, crc_byte_len_pair, mavlink::sensyn::Extension::Get())) {
+            &&  !sum.Get_extra_byte_length_pair(msg_id, crc_byte_len_pair, mavlink::sensyn::Extension::Get())
+            &&  !sum.Get_extra_byte_length_pair(msg_id, crc_byte_len_pair, mavlink::acsl::Extension::Get())) {
             std::lock_guard<std::mutex> stats_lock(stats_mutex);
             stats[mavlink::SYSTEM_ID_ANY].unknown_id++;
             // LOG_DEBUG("Unknown Mavlink message id: %d system id: %d component id: %d)", msg_id, system_id, component_id);

--- a/resources/mavlink/acsl.xml
+++ b/resources/mavlink/acsl.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- acsl custom message definitions                               -->
+  <!-- mavlink ID range 59001 - 59099                                -->
+  <include>common.xml</include>
+
+  <!-- MAVLink drone specific mavlink2 custom messages-->
+  <messages>
+    <message id="59002" name="ACSL_DRONE_HEALTH">
+      <description>ACSL Drone Health of vehicle hardware.</description>
+      <field type="uint8_t" name="upper_cpu_usage">Upper task CPU utilization</field>
+      <field type="uint8_t" name="lower_cpu_usage">Lower task CPU utilization</field>
+      <field type="int8_t" name="temperature">Temperature in vehicle</field>
+      <field type="uint8_t" name="imu_comm">IMU communication health. Range 0-15, good is above 10, bad is under 4, warning is 5 to 9. If not applicable, set 255.</field>
+      <field type="uint8_t" name="accel_data">Acceleration data quality. Range 0-15, good is above 10, bad is under 4, warning is 5 to 9. If not applicable, set 255.</field>
+      <field type="uint8_t" name="gyro_data">Gyroscope data quality</field>
+      <field type="uint8_t" name="mag_comm">Magnetometer communication health</field>
+      <field type="uint8_t" name="mag_data">Magnetometer data quality</field>
+      <field type="uint8_t" name="bar_comm">Barometer communication health</field>
+      <field type="uint8_t" name="bar_data">Barometer data quality</field>
+      <field type="uint8_t" name="gps_comm">GPS communication health</field>
+      <field type="uint8_t" name="gps_data">GPS data quality</field>
+      <field type="uint8_t" name="vision_comm">Vision communication health</field>
+      <field type="uint8_t" name="vision_data">Vision data quality</field>
+      <field type="uint8_t[6]" name=" rs_comm">Ranging sensor communication health</field>
+      <field type="uint8_t[6]" name="rs_data">Ranging sensor data quality</field>
+      <field type="uint8_t" name="pmu_comm">Power management unit communication health</field>
+      <field type="uint8_t" name="pmu_data">Power management unit data quality</field>
+      <field type="uint8_t" name="esc_comm">ESC communication health</field>
+      <field type="uint8_t[8]" name="esc_data">ESC health</field>
+      <field type="uint8_t" name="rc_comm">Radio controller communication health</field>
+      <field type="uint8_t[2]" name="gcs_comm">Ground control system communication health</field>
+      <field type="uint8_t" name="radio">Radio module health</field>
+      <field type="uint8_t" name="upper">Upper task health(lower task detection)</field>
+      <field type="uint8_t" name="lower">Lower task health(upper task detection)</field>
+      <field type="uint8_t[16]" name=" details">Specified devices detail</field>
+    </message>
+  </messages>
+</mavlink>


### PR DESCRIPTION
ACSL側、「Mavlink仕様R9」にDroneに関する健全度のカスタマイズMavlink Messageを追加しました。

PF Stationと同様に「Vision Sensorの健全度」等を表示には、該当カスタマイズMavlink Messageを追加対応します。

https://docs.google.com/spreadsheets/d/1MgG_S29yjEnOlaM-jg4ci5-NQrCOS0RJ/edit#gid=1409374291
HEALTH ( #59002 )