### PR TITLE
add Camera_control_action Get_value result

### DIFF
--- a/include/ugcs/vsm/camera_control_action.h
+++ b/include/ugcs/vsm/camera_control_action.h
@@ -30,29 +30,33 @@ public:
     Camera_control_action(const Property_list& p) :
         Action(Type::CAMERA_CONTROL)
     {
-        p.at("tilt")->Get_value(tilt);
-        p.at("roll")->Get_value(roll);
-        p.at("yaw")->Get_value(yaw);
-        p.at("zoom_level")->Get_value(zoom);
+        has_tilt = p.at("tilt")->Get_value(tilt);
+        has_roll = p.at("roll")->Get_value(roll);
+        has_yaw  = p.at("yaw")->Get_value(yaw);
+        has_zoom = p.at("zoom_level")->Get_value(zoom);
     }
 
     /** Target camera tilt value in radians: [-Pi/2, Pi/2], where -Pi/2 stands
      * for looking backward, 0 for full down and Pi/2 for looking straight forward.
      */
     double tilt;
+    bool has_tilt;
 
     /** Target camera roll value in radians: [-Pi/2, Pi/2], where -Pi/2 stands
      * for left and Pi/2 for right.
      */
     double roll;
+    bool has_roll;
 
     /** Target camera yaw value in radians: [-Pi/2, Pi/2], where -Pi/2 stands
      * for left and Pi/2 for right.
      */
     double yaw;
+    bool has_yaw;
 
     /** Device specific camera zoom level. */
     double zoom;
+    bool has_zoom;
 };
 
 /** Type mapper for camera control action. */


### PR DESCRIPTION
# 課題
vsm-cpp-sdkのCamera_control_actionには、サーバからアップロードした値を正しく取得できません。

- MissionのカメラYawを設定していない関わらず、Camera_control_action.yawで違う値が入っています。
![image](https://user-images.githubusercontent.com/10125455/160235411-fcaa7a01-c45c-4c0c-9a6e-ae800852f956.png)

- - Missionのカメラパラメータ（例：tilt）未設定時、0の値が入っています、未設定なのか、0で設定したかを区別できない。
![image](https://user-images.githubusercontent.com/10125455/160235488-d109a400-c483-4df2-8090-13b3e1506767.png)

# 修正
Camera_control_actionのGet_valueの取得した結果をbool変数(has_XXX)に保存して使用する

# テスト
Missionのカメラパラメータ設定した場合のみ、bool変数(has_XXX)がtrueになること　OK（上記画像を参考）

