### PR TITLE
Laser測距座標と高度のMAVLinkカスタマイズメッセージ追加

### DIFF
--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -18,6 +18,7 @@
       <field type="int32_t" name="lon" units="degE7">Longitude, expressed</field>
       <field type="int32_t" name="alt" units="mm">Altitude (MSL)</field>
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
+      <field type="int32_t" name="target_distance" units="mm">The range to the target object</field>
     </message>
   </messages>
 </mavlink>

--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -11,5 +11,13 @@
       <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the system (quadrotor, helicopter, etc.). Components use the same type as their associated system.</field>
       <field type="char[254]" name="serial_number_id">Drone serial number id, terminated by NULL if the length is less than 254 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 254 chars - applications have to provide 254+1 bytes storage if the ID is stored as string</field>
     </message>
+    <message id="13001" name="LASER_RANGING_POSITION_INT">
+      <description>The height and GPS position of the measured object (e.g. DJI H20T Laser Ranging). The position is in GPS-frame (right-handed, Z-up). It
+               is designed as scaled integer message since the resolution of float is not sufficient.</description>
+      <field type="int32_t" name="lat" units="degE7">Latitude, expressed</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude, expressed</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL)</field>
+      <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
# 課題
中電プロジェクトで、鉄塔などの座標、高さをレコーディング対応するため、H20T Laser測距対象座標と高度のメッセージをGCS側に送信必要があります。

現状流用できるLaser測距対象座標と高度のメッセージMAVLinkメッセージがないので、カスタマイズメッセージとして追加します。

# VSM SDKより自動生成したMAVLinkメッセージ

auto_mavlink_enums.h

```
namespace sensyn {
enum MESSAGE_ID: MESSAGE_ID_TYPE {
    /** MAVLink Drone serial number id.
     */
    SERIAL_NUMBER_ID = 13000,
    /** The height and GPS position of the measured object (e.g. DJI H20T Laser
     * Ranging). The position is in GPS-frame (right-handed, Z-up). It is
     * designed as scaled integer message since the resolution of float is not
     * sufficient.
     */
    LASER_RANGING_POSITION_INT = 13001,
};
} /* namespace sensyn */
```

auto_mavlink_messages.h

```
/** The height and GPS position of the measured object (e.g. DJI H20T Laser
 * Ranging). The position is in GPS-frame (right-handed, Z-up). It is
 * designed as scaled integer message since the resolution of float is not
 * sufficient.
 */
namespace sensyn {
namespace internal {
struct Pld_struct_laser_ranging_position_int {
    /** Reset all fields to UgCS default values
     */
    void
    Reset();
    /** Return message size on wire without extensions
     */
    size_t
    Get_size_v1() const {return 20;}
    /** Return max message size on wire with extensions
     */
    size_t
    Get_size_v2() const {return 20;}
    /** Latitude, expressed
     */
    Int32 lat;
    /** Longitude, expressed
     */
    Int32 lon;
    /** Altitude (MSL)
     */
    Int32 alt;
    /** Altitude above ground
     */
    Int32 relative_alt;
    /** The range to the target object
     */
    Int32 target_distance;
} __PACKED;
```

