### PR TITLE
Feature/enable mavlink2 on receive stream

### DIFF
--- a/include/ugcs/vsm/mavlink_decoder.h
+++ b/include/ugcs/vsm/mavlink_decoder.h
@@ -137,7 +137,7 @@ public:
                     for (; len_skipped < buffer_len; len_skipped++, data++) {
                         if (*data == mavlink::START_SIGN) {
                             // found preamble. Start receiving payload.
-                            is_mavlink2 = false;
+                            is_mavlink_v2 = false;
                             state = State::VER1;
                             stats[mavlink::SYSTEM_ID_ANY].stx_syncs++;
                             // slice off the preamble.
@@ -146,7 +146,7 @@ public:
                         }
                         if (*data == mavlink::START_SIGN2) {
                             // found preamble. Start receiving payload.
-                            is_mavlink2 = true;
+                            is_mavlink_v2 = true;
                             state = State::VER2;
                             stats[mavlink::SYSTEM_ID_ANY].stx_syncs++;
                             // slice off the preamble.
@@ -223,9 +223,9 @@ public:
     }
 
     bool
-    Is_mavlink2()
+    Is_mavlink_v2()
     {
-        return is_mavlink2;
+        return is_mavlink_v2;
     }
 
 private:
@@ -313,7 +313,7 @@ private:
     /** Current decoder state. */
     State state = State::STX;
 
-    bool is_mavlink2 = false;
+    bool is_mavlink_v2 = false;
 
     /** Handler for decoded messages. */
     Handler handler;

--- a/include/ugcs/vsm/mavlink_decoder.h
+++ b/include/ugcs/vsm/mavlink_decoder.h
@@ -137,6 +137,7 @@ public:
                     for (; len_skipped < buffer_len; len_skipped++, data++) {
                         if (*data == mavlink::START_SIGN) {
                             // found preamble. Start receiving payload.
+                            is_mavlink2 = false;
                             state = State::VER1;
                             stats[mavlink::SYSTEM_ID_ANY].stx_syncs++;
                             // slice off the preamble.
@@ -145,6 +146,7 @@ public:
                         }
                         if (*data == mavlink::START_SIGN2) {
                             // found preamble. Start receiving payload.
+                            is_mavlink2 = true;
                             state = State::VER2;
                             stats[mavlink::SYSTEM_ID_ANY].stx_syncs++;
                             // slice off the preamble.
@@ -218,6 +220,12 @@ public:
     {
         std::lock_guard<std::mutex> lock(stats_mutex);
         return stats[mavlink::SYSTEM_ID_ANY];
+    }
+
+    bool
+    Is_mavlink2()
+    {
+        return is_mavlink2;
     }
 
 private:
@@ -304,6 +312,8 @@ private:
 
     /** Current decoder state. */
     State state = State::STX;
+
+    bool is_mavlink2 = false;
 
     /** Handler for decoded messages. */
     Handler handler;

--- a/include/ugcs/vsm/mavlink_decoder.h
+++ b/include/ugcs/vsm/mavlink_decoder.h
@@ -74,6 +74,11 @@ public:
         uint64_t stx_syncs = 0;
     };
 
+    enum class MavlinkVersion {
+      V1,
+      V2
+    };
+
 
     /** Default constructor. */
     Mavlink_decoder():
@@ -137,7 +142,7 @@ public:
                     for (; len_skipped < buffer_len; len_skipped++, data++) {
                         if (*data == mavlink::START_SIGN) {
                             // found preamble. Start receiving payload.
-                            is_mavlink_v2 = false;
+                            mavlink_version = MavlinkVersion::V1;
                             state = State::VER1;
                             stats[mavlink::SYSTEM_ID_ANY].stx_syncs++;
                             // slice off the preamble.
@@ -146,7 +151,7 @@ public:
                         }
                         if (*data == mavlink::START_SIGN2) {
                             // found preamble. Start receiving payload.
-                            is_mavlink_v2 = true;
+                            mavlink_version = MavlinkVersion::V2;
                             state = State::VER2;
                             stats[mavlink::SYSTEM_ID_ANY].stx_syncs++;
                             // slice off the preamble.
@@ -222,10 +227,9 @@ public:
         return stats[mavlink::SYSTEM_ID_ANY];
     }
 
-    bool
-    Is_mavlink_v2()
-    {
-        return is_mavlink_v2;
+    MavlinkVersion
+    Get_mavlink_version() const {
+        return mavlink_version;
     }
 
 private:
@@ -313,7 +317,7 @@ private:
     /** Current decoder state. */
     State state = State::STX;
 
-    bool is_mavlink_v2 = false;
+    MavlinkVersion mavlink_version = MavlinkVersion::V1;
 
     /** Handler for decoded messages. */
     Handler handler;


### PR DESCRIPTION
機体からのMavlinkメッセージフォーマットがMAVLink 2かどうかを判別ため、is_mavlink_v2フラグを追加する。