### PR TITLE
Feature/send laser error data

### DIFF
--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -19,6 +19,8 @@
       <field type="int32_t" name="alt" units="mm">Altitude (MSL)</field>
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
       <field type="int32_t" name="target_distance" units="mm">The range to the target object</field>
+      <extensions/>
+      <field type="int32_t" name="error_state">The laser error from the laser sensor</field>
     </message>
     <message id="13002" name="POWERLINE_TRACKING_PARAM_SET">
       <description>Set powerline detection parameters.</description>


### PR DESCRIPTION
対応：
DJIのLaserMeasureInformationから測定エラー区分データを取得してVSMに追加送信
カスタマイズLASER_RANGING_POSITION_INTメッセージに項目を追加
error_state