### PR TITLE
add auto_focus_ring_value to POWERLINE_TRACKING_PARAM_SET Message

### DIFF
--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -30,6 +30,8 @@
       <field type="float" name="powerline_distance_m" units="m">powerline distance (meter)</field>
       <field type="int32_t" name="powerline_number">number of powerlines</field>
       <field type="int32_t" name="camera_automode_trigger_wp_index">camera automode trigger waypoint index</field>
+      <extensions/>
+      <field type="int32_t" name="auto_focus_ring_value">auto focus ring value</field>
     </message>
     <message id="13003" name="POWERLINE_TRACKING_PARAM_ACK">
       <description>Response from a POWERLINE_PARAM_SET message.</description>


### PR DESCRIPTION
### 目的

FlightEdgeアプリでカメラのFocusを自動調整するため、
PowerGridCheckサーバ側で、Focus値を計算して、VSM経由でFlightEdgeアプリに送信

https://sensyn-robotics.atlassian.net/wiki/spaces/SN/pages/768245925/Focus#%E8%87%AA%E5%8B%95Focus%E8%AA%BF%E6%95%B4%E3%81%AEPGC%E2%87%92VSM%E9%80%A3%E6%90%BA%E4%BB%95%E6%A7%98%E5%A4%89%E6%9B%B4%E5%AF%BE%E5%BF%9C

### 対応

まず、VSM SDK側VSM⇒FlightEdgeアプリに送信するMavlinkメッセージ（powerline_tracking_param_set）に
H20Tの Focus値(auto_focus_ring_value)を追加する

### テスト

- [x] 新VSM　⇒　旧FlightEdgeアプリへ正常にMavlinkメッセージを送信できること
- [x] 新VSM　⇒　新FlightEdgeアプリへ正常にMavlinkメッセージを送信できること