### PR TITLE
Feature/mission ellipsoid height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /**/html*
 # Ignore eclipse settings file
 .settings
+CMakeLists.txt.user
+

--- a/include/ugcs/vsm/task.h
+++ b/include/ugcs/vsm/task.h
@@ -56,6 +56,11 @@ public:
     void
     Set_takeoff_altitude(double altitude);
 
+    double
+    Get_takeoff_altitude_above_ground() const;
+    void
+    Set_takeoff_altitude_above_ground(double altitude);
+
     /** Action list of the task .*/
     std::vector<Action::Ptr> actions;
 
@@ -80,8 +85,14 @@ private:
     std::tuple<Wgs84_position, double>
     Get_home_position_impl() const;
 
-    /** Take-off altitude, should be set before giving the task for user. */
+    /** Take-off altitude above mean sea level, should be set before giving the task for user. */
     Optional<double> takeoff_altitude;
+
+    // Take-off point altitude above ground
+    // Sensyn specification
+    // Sensyn pilot will set 500m Take-off point altitude above ground into altitude_amsl for fly over some low altitude
+    // Not really set 500m altitude for fly height
+    double takeoff_altitude_above_ground = 0;
 };
 
 } /* namespace vsm */

--- a/include/ugcs/vsm/vehicle.h
+++ b/include/ugcs/vsm/vehicle.h
@@ -121,7 +121,7 @@ public:
     }
 
     static std::optional<double>
-    Get_takeoff_altitude(bool was_armed, const std::string& route_name);
+    Get_takeoff_altitude(const std::string& route_name);
 
     /** Hasher for Vehicle shared pointer. Used when vehicle pointer is
      * stored in some container. */

--- a/resources/mavlink/common.xml
+++ b/resources/mavlink/common.xml
@@ -648,6 +648,9 @@
       <entry value="19" name="MAV_FRAME_ESTIM_ENU">
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
       </entry>
+      <entry value="255" name="MAV_FRAME_GLOBAL_ELLIPSOID_ALT_EGM96">
+        <description>Global (WGS84) coordinate frame + Ellipsoid altitude. First value / x: latitude, second value / y: longitude, third value / z: Ellipsoid altitude against the reference ellipsoid (EGM96).</description>
+      </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
       <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">

--- a/resources/mavlink/common.xml
+++ b/resources/mavlink/common.xml
@@ -648,9 +648,6 @@
       <entry value="19" name="MAV_FRAME_ESTIM_ENU">
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
       </entry>
-      <entry value="255" name="MAV_FRAME_GLOBAL_ELLIPSOID_ALT_EGM96">
-        <description>Global (WGS84) coordinate frame + Ellipsoid altitude. First value / x: latitude, second value / y: longitude, third value / z: Ellipsoid altitude against the reference ellipsoid (EGM96).</description>
-      </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
       <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -37,6 +37,18 @@ Task::Set_takeoff_altitude(double altitude)
     takeoff_altitude = altitude;
 }
 
+double
+Task::Get_takeoff_altitude_above_ground() const
+{
+    return takeoff_altitude_above_ground;
+}
+
+void
+Task::Set_takeoff_altitude_above_ground(double altitude)
+{
+    takeoff_altitude_above_ground = altitude;
+}
+
 std::tuple<Wgs84_position, double>
 Task::Get_home_position_impl() const
 {

--- a/test/unit/ut_vehicle.cpp
+++ b/test/unit/ut_vehicle.cpp
@@ -160,12 +160,11 @@ TEST(basic_usage)
 TEST(get_takeoff_altitude_500)
 {
     // Test takeOffAltitude is 500.0
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOffAltitude":500.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK_EQUAL(500.0, takeoff_altitude.value());
 }
 
@@ -177,112 +176,102 @@ TEST(get_takeoff_altitude_600)
     const std::string json = R"({"takeOffAltitude":600.5})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK_EQUAL(600.5, takeoff_altitude.value());
 }
 
 TEST(get_takeoff_altitude_0)
 {
     // Test takeOffAltitude is 0.0
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOffAltitude":0.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK_EQUAL(0.0, takeoff_altitude.value());
 }
 
 TEST(get_takeoff_altitude_not_armed)
 {
-    // Test not armed
-    bool was_armed = false;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOffAltitude":500.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
-    CHECK(std::nullopt == takeoff_altitude);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
+    CHECK_EQUAL(500.0, takeoff_altitude.value());
 }
 
 TEST(get_takeoff_altitude_json_format_blank_character)
 {
     // Test takeOffAltitude json str have blank character
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOffAltitude": 500.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK_EQUAL(500.0, takeoff_altitude.value());
 }
 
 TEST(get_takeoff_altitude_json_format_int_value)
 {
     // Test takeOffAltitude json str have int value
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOffAltitude": 500})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK_EQUAL(500.0, takeoff_altitude.value());
 }
 
 TEST(get_takeoff_altitude_json_format_key_takeOff)
 {
     // Test takeOffAltitude json str have a wrong key
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOff": 500.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK(std::nullopt == takeoff_altitude);
 }
 
 TEST(get_takeoff_altitude_json_format_key_land)
 {
     // Test takeOffAltitude json str have a wrong key
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"land": 500.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK(std::nullopt == takeoff_altitude);
 }
 
 TEST(get_takeoff_altitude_json_format_key_case_sensitive)
 {
     // Test takeOffAltitude json str have a wrong case-sensitive key(lowercase)
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeoffaltitude": 500.0})";
     const auto route_name = std::string(name + '\0' + json, 0, name. size() + 1 + json.size());
     LOG("Embedded null character route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK(std::nullopt == takeoff_altitude);
 }
 
 TEST(get_takeoff_altitude_json_format_no_null_character)
 {
     // Test takeOffAltitude json str have no Embedded null character in route_name
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     const std::string json = R"({"takeOffAltitude": 500.0})";
     const auto route_name = std::string(name + json, 0, name. size() + json.size());
     LOG("route_name: %s", route_name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, route_name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(route_name);
     CHECK(std::nullopt == takeoff_altitude);
 }
 
 TEST(get_takeoff_altitude_json_format_no_json_str)
 {
     // Test have no takeOffAltitude json str in route_name
-    bool was_armed = true;
     const std::string name = "0-M300RTK-xxxxxxxx";
     LOG("route_name: %s", name.c_str());
-    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(was_armed, name);
+    std::optional<double> takeoff_altitude = Vehicle::Get_takeoff_altitude(name);
     CHECK(std::nullopt == takeoff_altitude);
 }


### PR DESCRIPTION
楕円体高度対応

楕円体高度対応には、VSMからDroneに転送するMissionのWaypointに海抜高度AMSLを設定したい。
但し、SensyPilot側、地面より低いルートを飛ばすため、
Waypointの海抜高度AMSLに500mのtakeoff_altitude_above_groundが含まれています。
Waypointの海抜高度AMSLから500mのtakeoff_altitude_above_groundを除くため、
500mのtakeoff_altitude_above_groundの設定値をMission情報（Misson名前）から取得して各Waypointの高度計算処理に使用する。

本当のWaypointの海抜高度AMSL＝Ugcsから受信したWaypointの海抜高度AMSL　ー　500mのtakeoff_altitude_above_ground