### PR TITLE
add RTK_USED_STATUS and LIDAR_SENSOR_QUALITY for ELAS

### DIFF
--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -47,5 +47,13 @@
       <description>Response from a POWERLINE_PARAM_SET message.</description>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
+    <message id="13006" name="RTK_USED_STATUS">
+      <description>RTK used status.</description>
+      <field type="uint8_t" name="rtk_used_status">RTK used status</field>
+    </message>
+    <message id="13007" name="LIDAR_SENSOR_QUALITY">
+      <description>Lidar sensor quality.</description>
+      <field type="uint8_t" name="lidar_sensor_quality">Lidar sensor quality</field>
+    </message>
   </messages>
 </mavlink>

--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -47,9 +47,9 @@
       <description>Response from a POWERLINE_PARAM_SET message.</description>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
-    <message id="13006" name="RTK_USED_STATUS">
-      <description>RTK used status.</description>
-      <field type="uint8_t" name="rtk_used_status">RTK used status</field>
+    <message id="13006" name="RTK_USAGE_STATUS">
+      <description>RTK usage status.</description>
+      <field type="uint8_t" name="rtk_usage_status">RTK usage status</field>
     </message>
     <message id="13007" name="LIDAR_SENSOR_QUALITY">
       <description>Lidar sensor quality.</description>


### PR DESCRIPTION
# 対応

ELASのRTK使用状況とLiDAR測位状態テレメトリ連携ため、カスタマイズMavlinkメッセージを追加します。

RTK使用状況：(RTK_USAGE_STATUS)
使用中
不使用


LiDAR測位状態：(LIDAR_SENSOR_QUALITY)
良好
悪い
使用不可

VSM_SensynPilot_連携仕様
https://docs.google.com/spreadsheets/d/174eHGpefpelDr78CiHmDJzHdelR1AKrqeRq3YiqR3qs/edit#gid=0

# テスト

- [x] Gcsに下記テレメトリが送信されていること

- RTK測位状態　gps_fix
- LiDAR測位状態　lidar_sensor_quality
- RTK使用状況　rtk_usage_status

![image](https://github.com/sensyn-robotics/mavlink_proxy_ros/assets/10125455/683533bd-61e4-4b8a-b515-85764d9dda72)

![image](https://github.com/sensyn-robotics/mavlink_proxy_ros/assets/10125455/e37c7f5e-fccc-4350-88a3-4e6a0347e04b)

![image](https://github.com/sensyn-robotics/mavlink_proxy_ros/assets/10125455/4af3bc80-f318-405c-a373-2a4df811df0b)





