### PR TITLE
Feature/using hl altitude as altitude origin

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -458,6 +458,8 @@ Vehicle::Handle_ucs_command(
                     altitude_origin = hl + task->payload.Get_takeoff_altitude_above_ground();
                     LOG("Using current Home Location altitude %f m as altitude origin when drone is armed.", hl);
                     LOG("Modified Altitude origin: %f", altitude_origin);
+                } else {
+                    LOG("Using altitude origin %f m from route.", altitude_origin);
                 }
                 task->payload.Set_takeoff_altitude(altitude_origin);
             } else {


### PR DESCRIPTION
# Bug
ドロンが屋上状態しても、テレメトリ送信開始すると、altitude AGLとaltitude AMSLリセットされる現象があります。
altitude AGL ⇒　0
altitude AMSL ⇒ altitude elevation

# 修正
altitude_originテレメトリを送信停止すると、該当現象を解消できます。

但し、altitude_originテレメトリを送信停止すると、以前中電対応した不具合現象
（ドロンが空中でMissionアップロードした時に、altitude_origin正常に更新されない現象）
[空中ホバリングで高さ30mを設定したが90mに上昇現象不具合の修正 #32 ](https://github.com/sensyn-robotics/acsl-vsm-mavlink/pull/32)
がまた発生ため、
空中でMissionアップロード場合、altitude_origin代わりに、home_altitude_amslを使用するように変更します。
https://github.com/sensyn-robotics/acsl-vsm-mavlink/pull/55


### vsm-cpp-sdk 側の修正
空中でMissionアップロード場合、altitude_origin代わりに、home_altitude_amslをSet_takeoff_altitude()に設定するように変更します。
https://github.com/sensyn-robotics/vsm-cpp-sdk/pull/17

### mavlink-proxy-client側の修正
Old flight edge v4の接続区別ため、autopilot_versionメッセージにflight_custom_versionのデータを追加します。
https://github.com/sensyn-robotics/mavlink-proxy-client/pull/8



# テスト

- [x] ドロンが屋上状態しても、テレメトリ送信開始すると、altitude AGLとaltitude AMSLリセットされないこと。
- [x] 地面Disarm状態で、Missionアップロード時に、ルートのaltitude_originが使用されること
- [x] 空中でMissionアップロード場合、home_altitude_amslが使用されること


https://github.com/sensyn-robotics/acsl-vsm-mavlink/assets/10125455/13b389c4-3b51-4b21-8b54-daaf97867271






