### PR TITLE
add gcs_homepoint_elevation

### DIFF
--- a/include/ugcs/vsm/task.h
+++ b/include/ugcs/vsm/task.h
@@ -56,6 +56,14 @@ public:
     void
     Set_takeoff_altitude(double altitude);
 
+    /** Get GCS home point elevation. */
+    double
+    Get_gcs_homepoint_elevation() const;
+
+    /** Set GCS home point elevation. */
+    void
+    Set_gcs_homepoint_elevation(double altitude);
+
     double
     Get_takeoff_altitude_above_ground() const;
     void
@@ -87,6 +95,9 @@ private:
 
     /** Take-off altitude above mean sea level, should be set before giving the task for user. */
     Optional<double> takeoff_altitude;
+
+    // Gcs home point elevation above mean sea level
+    Optional<double> gcs_homepoint_elevation;
 
     // Take-off point altitude above ground
     // Sensyn specification

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -23,6 +23,22 @@ Task::Get_home_position_altitude() const
 }
 
 double
+Task::Get_gcs_homepoint_elevation() const
+{
+    if (!gcs_homepoint_elevation) {
+        VSM_EXCEPTION(Internal_error_exception, "Gcs homepoint elevation not set in task.");
+    }
+    return *gcs_homepoint_elevation;
+}
+
+void
+Task::Set_gcs_homepoint_elevation(double altitude)
+{
+    gcs_homepoint_elevation = altitude;
+}
+
+
+double
 Task::Get_takeoff_altitude() const
 {
     if (!takeoff_altitude) {


### PR DESCRIPTION
# 課題

ドロンが空中でMissionアップロードした時に、Ugcs側altitude_originを正常に更新しない現象があります。

以前は、HPテレメトリを受信タイミングで、altitude originを更新する方法で、中電の空中アップロードできるようにしたが、副作用があります。
副作用：ELAS案件で、屋上ドロン起動した場合、AGLのテレメトリが30mしても、altitude originを更新すると、Ugcs側強制的にAGLのテレメトリを0にリセットしています。

空中アップロード場合、altitude originを更新修正方法をやめて、DJIから取得したHPの海抜高度をaltitude originとして使用方法に変更しましたが、https://github.com/sensyn-robotics/vsm-cpp-sdk/pull/17
副作用があります。

副作用：地面より高い位置からTakeoffして空中でMissionアップロード場合、DJIから取得したそのHPの海抜高度は、UgcsのHPの地面elevationと誤差が出ています。

![image](https://github.com/sensyn-robotics/vsm-cpp-sdk/assets/10125455/a62607bd-a408-49cf-a6ef-1d143a84b6e8)


# 再修正
PGC側、Mission転送時に、HPのUgcs elevationを取得してVSMに送信
VSM側、空中アップロード場合、受信したHPのUgcs elevation＋Takeoff Point高度（ex. 500m）をaltitude originとして使用する
　　　　地面アップロード場合、今まで通りで、Ugcsからのルート中のaltitude origin「Takeoff Point高度（ex. 500m）含み」を使用する

acsl-vsm-mavlink側の修正
https://github.com/sensyn-robotics/acsl-vsm-mavlink/pull/56