### PR TITLE
Feature/add rtk telemetry msg

### DIFF
--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -58,7 +58,7 @@
       <description>Lidar sensor quality.</description>
       <field type="uint8_t" name="lidar_sensor_quality">Lidar sensor quality</field>
     </message>
-    <message id="13008" name="RTK_FIX_STATUS">
+    <message id="13008" name="RTK_STATUS">
       <description>RTK system fix status.</description>
       <field type="uint8_t"  name="is_rtk_enabled">RTKSystemState.getIsRTKEnabled</field>
       <field type="uint8_t"  name="is_rtk_connected">RTKSystemState.getRTKConnected</field>

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -12,10 +12,10 @@
 #include <ugcs/vsm/actions.h>
 
 #include <iostream>
-#include "rapidjson/document.h"
+#include <nlohmann/json.hpp>
 
 using namespace ugcs::vsm;
-using namespace rapidjson;
+using json = nlohmann::json;
 
 std::hash<Vehicle*> Vehicle::Hasher::hasher;
 
@@ -368,12 +368,11 @@ Vehicle::Get_takeoff_altitude(const std::string& route_name)
     // parse json str after found embedded null character('\0')
     const auto& json_str = route_name.substr(nul_pos + 1);
     LOG("Take-off point altitude json: %s", json_str.c_str());
-    Document j;
-    j.Parse(json_str.c_str());
+    const json j = json::parse(json_str);
     const std::string key = "takeOffAltitude";
-    if (j.HasMember(key.c_str())) {
-        LOG("Take-off point altitude: %f", j[key.c_str()].GetDouble());
-        return j[key.c_str()].GetDouble();
+    if (j.find(key) != j.end()) {
+        LOG("Take-off point altitude: %f", j[key].get<double>());
+        return j[key].get<double>();
     } else {
         LOG("Not found json key: %s in route_name", key.c_str());
     }


### PR DESCRIPTION
RTK 測位なぜFixしないかの問い合わせ運用課題対応で、
RTK FIX状態調査ため、RTK 測位状態テレメトリ送信を追加します。

RTK 測位状態メッセージ（RTK_FIX_STATUS）：

- is_rtk_enabled
- is_rtk_connected
- is_rtk_healthy
- rtk_pos_solution
- rtk_source_type
- gps_satellite_count
- rtk_satellite_count
- gps_signal_level
- rtk_network_service_status

RTK起動時文字列エラーコードメッセージ（RTK_ERROR_CODE）

- rtk_error_code　（最大254Byte、通信量減らすため、長い文字列通信は必要なタイミングだけ送信）


https://sensyn-robotics.atlassian.net/wiki/spaces/SN/pages/1791033537/Flightedge+RTK

関連システムの改修PR：
