### PR TITLE
add camera speed pid

### DIFF
--- a/resources/mavlink/sensyn.xml
+++ b/resources/mavlink/sensyn.xml
@@ -45,6 +45,12 @@
       <extensions/>
       <field type="float" name="vertical_sensor_size">camera's vertical sensor size (mm)</field>
       <field type="float" name="horizontal_sensor_size">camera's horizontal sensor size (mm)</field>
+      <field type="float" name="camera_pitch_speed_pid_p">camera pitch speed PID (P)</field>
+      <field type="float" name="camera_pitch_speed_pid_i">camera pitch speed PID (I)</field>
+      <field type="float" name="camera_pitch_speed_pid_d">camera pitch speed PID (D)</field>
+      <field type="float" name="camera_roll_speed_pid_p">camera roll speed PID (P)</field>
+      <field type="float" name="camera_roll_speed_pid_i">camera roll speed PID (I)</field>
+      <field type="float" name="camera_roll_speed_pid_d">camera roll speed PID (D)</field>
     </message>
     <message id="13005" name="MISSION_SETTINGS_ACK">
       <description>Response from a POWERLINE_PARAM_SET message.</description>


### PR DESCRIPTION
Flightedge 電線追尾PIDがカメラ毎に特性が違うので、PID値がカメラ毎に持つ必要です。

カメラ毎のPID値がPGC側管理して、missionSettingsコマンドで

    cameraPitchSpeedPid

    cameraRollSpeedPid

PGC→VSM→Flightedgeの連携追加する。

```
{
    "command_name": "missionSettings",
    "parameters": {
...
        "cameraPitchSpeedPid": {"p":18.0, "i":0.018, "d":0.18 },
        "cameraRollSpeedPid": {"p":18.0, "i":0.018, "d":0.18 }
    }
}
```

https://sensyn-robotics.atlassian.net/wiki/spaces/SN/pages/1892974612/Flightedge+PID

該当PRは、VSM→FlightedgeのMavlink電文を追加する。
Mavlink電文転送サイズ縮小と転送効率向上ため、文字列JSONデータを各Float数値で転送します。